### PR TITLE
Fully implement pulling data from connector

### DIFF
--- a/cape/__init__.py
+++ b/cape/__init__.py
@@ -1,0 +1,3 @@
+from .coordinator import login
+
+__all__ = ["login"]

--- a/cape/connector/__init__.py
+++ b/cape/connector/__init__.py
@@ -1,0 +1,3 @@
+from .client import Client
+
+__all__ = ["Client"]

--- a/cape/connector/client_test.py
+++ b/cape/connector/client_test.py
@@ -1,3 +1,5 @@
+from cape.utils import base64
+
 from .client import Client
 from .stream_test import MockIterator
 
@@ -6,14 +8,14 @@ class MockStub:
     def __init__(self, iterations):
         self.iterations = iterations
 
-    def Query(self, request):
+    def Query(self, request, credentials):
         return MockIterator(self.iterations)
 
 
 def test_client(mocker):
     iterations = 10
 
-    client = Client("localhost:8081")
+    client = Client("localhost:8081", base64.from_string("MYCOOLTOKEN"))
 
     # override here so it doesn't actually do networking
     client.stub = MockStub(iterations)

--- a/cape/coordinator/__init__.py
+++ b/cape/coordinator/__init__.py
@@ -1,0 +1,4 @@
+from .client import Client
+from .client import login
+
+__all__ = ["Client", "login"]


### PR DESCRIPTION
Closes https://github.com/capeprivacy/planning/issues/1050

With the current changes the API will look something like:

```
import cape

cl = cape.login("API TOKEN")

cl.pull("creditcards", "SELECT * FROM transactions", 50, 0)
```