### PR TITLE
moved docstrings so they're not first line in the file

### DIFF
--- a/cape_privacy/pandas/registry.py
+++ b/cape_privacy/pandas/registry.py
@@ -1,13 +1,14 @@
-from typing import Callable
-from typing import Dict
+from typing import Callable, Dict
 
-from cape_privacy.pandas.transformations import ColumnRedact
-from cape_privacy.pandas.transformations import DatePerturbation
-from cape_privacy.pandas.transformations import DateTruncation
-from cape_privacy.pandas.transformations import NumericPerturbation
-from cape_privacy.pandas.transformations import NumericRounding
-from cape_privacy.pandas.transformations import RowRedact
-from cape_privacy.pandas.transformations import Tokenizer
+from cape_privacy.pandas.transformations import (
+    ColumnRedact,
+    DatePerturbation,
+    DateTruncation,
+    NumericPerturbation,
+    NumericRounding,
+    RowRedact,
+    Tokenizer,
+)
 
 TransformationCtor = Callable
 

--- a/cape_privacy/pandas/transformations/perturbation.py
+++ b/cape_privacy/pandas/transformations/perturbation.py
@@ -1,7 +1,5 @@
 import datetime
-from typing import Optional
-from typing import Tuple
-from typing import Union
+from typing import Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd

--- a/cape_privacy/pandas/transformations/perturbation_test.py
+++ b/cape_privacy/pandas/transformations/perturbation_test.py
@@ -5,8 +5,7 @@ import pandas as pd
 import pandas.testing as pdt
 
 from cape_privacy.pandas import dtypes
-from cape_privacy.pandas.transformations import DatePerturbation
-from cape_privacy.pandas.transformations import NumericPerturbation
+from cape_privacy.pandas.transformations import DatePerturbation, NumericPerturbation
 
 
 def test_perturbation_float():

--- a/cape_privacy/pandas/transformations/rounding_test.py
+++ b/cape_privacy/pandas/transformations/rounding_test.py
@@ -5,8 +5,7 @@ import pandas as pd
 import pandas.testing as pdt
 
 from cape_privacy.pandas import dtypes
-from cape_privacy.pandas.transformations import DateTruncation
-from cape_privacy.pandas.transformations import NumericRounding
+from cape_privacy.pandas.transformations import DateTruncation, NumericRounding
 
 
 def _make_apply_numeric_rounding(input, expected_output, ctype, dtype):

--- a/cape_privacy/policy/data.py
+++ b/cape_privacy/policy/data.py
@@ -1,4 +1,6 @@
 from typing import List
+
+
 """Contains the policy classes that are initialized from a yaml policy file.
 
 There are five main classes with Policy being the top level class. Policy contains
@@ -14,6 +16,7 @@ contain Transformations.
     # passes them in has keyword arguments.
     policy = Policy(**d)
 """
+
 
 class Transform:
     """A actual transform that will be applied.

--- a/cape_privacy/policy/data.py
+++ b/cape_privacy/policy/data.py
@@ -1,3 +1,5 @@
+from typing import List
+
 """Contains the policy classes that are initialized from a yaml policy file.
 
 There are five main classes with Policy being the top level class. Policy contains
@@ -13,10 +15,6 @@ contain Transformations.
     # passes them in has keyword arguments.
     policy = Policy(**d)
 """
-
-from typing import List
-
-
 class Transform:
     """A actual transform that will be applied.
 

--- a/cape_privacy/policy/data.py
+++ b/cape_privacy/policy/data.py
@@ -1,5 +1,4 @@
 from typing import List
-
 """Contains the policy classes that are initialized from a yaml policy file.
 
 There are five main classes with Policy being the top level class. Policy contains
@@ -15,6 +14,7 @@ contain Transformations.
     # passes them in has keyword arguments.
     policy = Policy(**d)
 """
+
 class Transform:
     """A actual transform that will be applied.
 

--- a/cape_privacy/policy/policy.py
+++ b/cape_privacy/policy/policy.py
@@ -1,3 +1,16 @@
+import types
+from typing import Callable
+
+import pandas as pd
+import requests
+import validators
+import yaml
+
+from cape_privacy import pandas as pandas_lib
+from cape_privacy import spark as spark_lib
+from cape_privacy.policy import data
+from cape_privacy.policy import exceptions
+
 """Utils for parsing policy and applying them.
 
 The module reads in policy as yaml and then through apply_policy
@@ -28,19 +41,6 @@ Applying policy:
     df = pd.DataFrame(np.ones(5,), columns=["value"])
     df = apply_policy(policy, df)
 """
-
-import types
-from typing import Callable
-
-import pandas as pd
-import requests
-import validators
-import yaml
-
-from cape_privacy import pandas as pandas_lib
-from cape_privacy import spark as spark_lib
-from cape_privacy.policy import data
-from cape_privacy.policy import exceptions
 
 
 def apply_policy(policy: data.Policy, df, inplace=False):

--- a/cape_privacy/policy/policy.py
+++ b/cape_privacy/policy/policy.py
@@ -3,13 +3,14 @@ from typing import Callable
 
 import pandas as pd
 import requests
-import validators
 import yaml
 
+import validators
 from cape_privacy import pandas as pandas_lib
 from cape_privacy import spark as spark_lib
-from cape_privacy.policy import data
-from cape_privacy.policy import exceptions
+from cape_privacy.policy import data, exceptions
+
+
 """Utils for parsing policy and applying them.
 
 The module reads in policy as yaml and then through apply_policy
@@ -40,6 +41,7 @@ Applying policy:
     df = pd.DataFrame(np.ones(5,), columns=["value"])
     df = apply_policy(policy, df)
 """
+
 
 def apply_policy(policy: data.Policy, df, inplace=False):
     """Applies a Policy to some DataFrame.

--- a/cape_privacy/policy/policy.py
+++ b/cape_privacy/policy/policy.py
@@ -10,7 +10,6 @@ from cape_privacy import pandas as pandas_lib
 from cape_privacy import spark as spark_lib
 from cape_privacy.policy import data
 from cape_privacy.policy import exceptions
-
 """Utils for parsing policy and applying them.
 
 The module reads in policy as yaml and then through apply_policy
@@ -41,7 +40,6 @@ Applying policy:
     df = pd.DataFrame(np.ones(5,), columns=["value"])
     df = apply_policy(policy, df)
 """
-
 
 def apply_policy(policy: data.Policy, df, inplace=False):
     """Applies a Policy to some DataFrame.

--- a/cape_privacy/policy/policy_test.py
+++ b/cape_privacy/policy/policy_test.py
@@ -10,8 +10,7 @@ import yaml
 from cape_privacy import pandas as pandas_lib
 from cape_privacy import spark as spark_lib
 from cape_privacy.pandas.transformations import test_utils
-from cape_privacy.policy import data
-from cape_privacy.policy import exceptions
+from cape_privacy.policy import data, exceptions
 from cape_privacy.policy import policy as policy_lib
 from cape_privacy.policy import policy_test_fixtures as fixtures
 

--- a/cape_privacy/spark/registry.py
+++ b/cape_privacy/spark/registry.py
@@ -1,10 +1,11 @@
-from typing import Callable
-from typing import Dict
+from typing import Callable, Dict
 
-from cape_privacy.spark.transformations import perturbation
-from cape_privacy.spark.transformations import redaction
-from cape_privacy.spark.transformations import rounding
-from cape_privacy.spark.transformations import tokenizer
+from cape_privacy.spark.transformations import (
+    perturbation,
+    redaction,
+    rounding,
+    tokenizer,
+)
 
 TransformationCtor = Callable
 

--- a/cape_privacy/spark/transformations/perturbation.py
+++ b/cape_privacy/spark/transformations/perturbation.py
@@ -1,15 +1,13 @@
-from typing import Optional
-from typing import Tuple
-from typing import Union
+from typing import Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
-from pyspark import sql
-from pyspark.sql import functions
 
 from cape_privacy.spark import dtypes
 from cape_privacy.spark.transformations import base
 from cape_privacy.utils import typecheck
+from pyspark import sql
+from pyspark.sql import functions
 
 _FREQUENCY_TO_DELTA_FN = {
     "YEAR": lambda noise: pd.to_timedelta(noise * 365, unit="days"),

--- a/cape_privacy/spark/transformations/perturbation_test.py
+++ b/cape_privacy/spark/transformations/perturbation_test.py
@@ -1,10 +1,9 @@
 import numpy as np
 import pandas as pd
-from pyspark.sql import functions
 
-from cape_privacy.spark import dtypes
-from cape_privacy.spark import utils
+from cape_privacy.spark import dtypes, utils
 from cape_privacy.spark.transformations import perturbation as ptb
+from pyspark.sql import functions
 
 
 def _make_and_apply_numeric_ptb(sess, df, dtype, min, max):

--- a/cape_privacy/spark/transformations/rounding.py
+++ b/cape_privacy/spark/transformations/rounding.py
@@ -1,9 +1,8 @@
-from pyspark import sql
-from pyspark.sql import functions
-
 from cape_privacy.spark import dtypes
 from cape_privacy.spark.transformations import base
 from cape_privacy.utils import typecheck
+from pyspark import sql
+from pyspark.sql import functions
 
 
 class NumericRounding(base.Transformation):

--- a/cape_privacy/spark/transformations/rounding_test.py
+++ b/cape_privacy/spark/transformations/rounding_test.py
@@ -2,11 +2,10 @@ import datetime
 
 import numpy as np
 import pandas as pd
-from pyspark.sql import functions
 
-from cape_privacy.spark import dtypes
-from cape_privacy.spark import utils
+from cape_privacy.spark import dtypes, utils
 from cape_privacy.spark.transformations import rounding as rnd
+from pyspark.sql import functions
 
 
 # Utils

--- a/cape_privacy/spark/transformations/tokenizer.py
+++ b/cape_privacy/spark/transformations/tokenizer.py
@@ -2,11 +2,11 @@ import hashlib
 import secrets
 
 import pandas as pd
-from pyspark.sql import functions
 
 from cape_privacy.spark import dtypes
 from cape_privacy.spark.transformations import base
 from cape_privacy.utils import typecheck
+from pyspark.sql import functions
 
 
 class Tokenizer(base.Transformation):

--- a/cape_privacy/spark/transformations/tokenizer_test.py
+++ b/cape_privacy/spark/transformations/tokenizer_test.py
@@ -1,9 +1,9 @@
 import pandas as pd
 import pandas.testing as pdt
-from pyspark.sql import functions
 
 from cape_privacy.spark import utils
 from cape_privacy.spark.transformations import tokenizer as tkn
+from pyspark.sql import functions
 
 
 def _make_and_apply_tokenizer(sess, df, max_token_len, key):

--- a/cape_privacy/spark/transformer.py
+++ b/cape_privacy/spark/transformer.py
@@ -1,7 +1,6 @@
+from cape_privacy.spark.transformations import base as tfm
 from pyspark import sql
 from pyspark.sql import functions
-
-from cape_privacy.spark.transformations import base as tfm
 
 
 def transformer(transformation: tfm.Transformation, df: sql.DataFrame, field_name: str):

--- a/cape_privacy/spark/utils.py
+++ b/cape_privacy/spark/utils.py
@@ -1,5 +1,6 @@
-import pyspark
 from packaging import version
+
+import pyspark
 from pyspark import sql
 
 _3_0_0_VERSION = version.Version("3.0.0")


### PR DESCRIPTION
A minor edit - docstrings as the first thing in a file lead to slightly inconsistent formatting in the autogenerated docs