### PR TITLE
Adds secret arguments to named transformations

### DIFF
--- a/cape_privacy/coordinator/client.py
+++ b/cape_privacy/coordinator/client.py
@@ -36,6 +36,29 @@ class GraphQLException(Exception):
         self.errors = [GraphQLError(error) for error in errors]
 
 
+class CapeError:
+    """Represents a Cape error coming from the coordinator.
+
+    Attributes:
+        messages: A list of error messages
+        cause: The cause of the error
+    """
+
+    def __init__(self, error):
+        self.messages = error["messages"]
+        self.cause = error["cause"]
+
+
+class CapeException(Exception):
+    """Exception wrapping a CapeError.
+    Attributes:
+        error: the CapeError
+    """
+
+    def __init__(self, error):
+        self.error = error
+
+
 class Client:
     """Coordinator client for making GraphQL requests.
 
@@ -106,6 +129,9 @@ class Client:
             j = r.json()
         except ValueError:
             r.raise_for_status()
+
+        if "cause" in j:
+            raise CapeException(j)
 
         self.token = base64.from_string(j["token"])
 

--- a/cape_privacy/policy/data.py
+++ b/cape_privacy/policy/data.py
@@ -108,6 +108,18 @@ class NamedTransform:
         self.type = type
         self.args = kwargs
 
+        for key, arg in self.args.items():
+            # if an arg is a secret
+            if isinstance(arg, dict) and "type" in arg and arg["type"] == "secret":
+                if "value" not in arg:
+                    raise ValueError(
+                        "Secret named transformation arg"
+                        + f"{arg['name']} must contain a value"
+                    )
+
+                # then set the arg value to the inner value
+                self.args[key] = arg["value"]
+
 
 class Policy:
     """Top level policy object.

--- a/cape_privacy/policy/data_test.py
+++ b/cape_privacy/policy/data_test.py
@@ -1,6 +1,7 @@
 import yaml
 
 from .data import Policy
+from .policy_test_fixtures import named_with_secret_y
 
 y = """
     label: test_policy
@@ -52,3 +53,11 @@ def test_policy_class():
     assert builtinTransform.field == "test"
     assert builtinTransform.type == "plusN"
     assert builtinTransform.args["n"] == 1
+
+
+def test_policy_with_secret():
+    d = yaml.load(named_with_secret_y, Loader=yaml.FullLoader)
+
+    p = Policy(**d)
+
+    assert p.transformations[1].args["key"] == "BASE"

--- a/cape_privacy/policy/policy_test_fixtures.py
+++ b/cape_privacy/policy/policy_test_fixtures.py
@@ -33,6 +33,29 @@ named_y = """
               name: plusTwo
     """
 
+named_with_secret_y = """
+    version: 1
+    label: test_policy
+    transformations:
+      - name: plusOne
+        type: plusN
+        n: 1
+      - name: tokenWithSecret
+        type: tokenizer
+        key:
+          type: secret
+          name: my-key
+          value: BASE
+    rules:
+      - match:
+          name: test
+        actions:
+          - transform:
+              name: plusOne
+          - transform:
+              name: plusTwo
+    """
+
 
 def named_not_found_y(saved_tfm, ref_tfm, tfm_type):
     return """


### PR DESCRIPTION
The intention of this is that the arguments will be stored securely on
the coordinator and a cape-python client can then request the policy
with these secret arguments decrypted.