### PR TITLE
Fix date assertion check

### DIFF
--- a/cape_privacy/pandas/transformations/perturbation.py
+++ b/cape_privacy/pandas/transformations/perturbation.py
@@ -110,7 +110,7 @@ class DatePerturbation(base.Transformation):
         is_date_no_time = False
 
         # Use equality instead of isinstance because of inheritance
-        if type(x[0]) == datetime.date:
+        if type(x.iloc[0]) == datetime.date:
             x = pd.to_datetime(x)
             is_date_no_time = True
 

--- a/cape_privacy/pandas/transformations/rounding.py
+++ b/cape_privacy/pandas/transformations/rounding.py
@@ -97,7 +97,7 @@ class DateTruncation(base.Transformation):
             raise ValueError
 
         # Use equality instead of isintance because of inheritance
-        if type(x[0]) == datetime.date:
+        if type(x.iloc[0]) == datetime.date:
             return pd.Series(truncated).dt.date
         else:
             return pd.Series(truncated)


### PR DESCRIPTION
Hey,

iI the first row was redacted, the following expression will throw an error x[0]. To get the first item in the Pandas Series need to use `x.iloc[0]` instead. See [stackoverflow conversation](https://stackoverflow.com/questions/47603430/pandas-libs-hashtable-pyobjecthashtable-get-item-keyerror-0/47604605) as reference.

Thanks,